### PR TITLE
Add numeric-id option for Flickr

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2781,6 +2781,17 @@ Description
     See `flickr.people.getInfo <https://www.flickr.com/services/api/flickr.people.getInfo.html>`__ for details.
 
 
+extractor.flickr.numeric-id
+---------------------------
+Type
+    ``bool``
+Default
+    ``false``
+Description
+    Use the numeric identifier (NSID) of a Flickr user as the
+    output directory name instead of the username.
+
+
 extractor.flickr.videos
 -----------------------
 Type

--- a/docs/gallery-dl-example.conf
+++ b/docs/gallery-dl-example.conf
@@ -149,7 +149,8 @@
         {
             "access-token": "1234567890-abcdef",
             "access-token-secret": "1234567890abcdef",
-            "size-max": 1920
+            "size-max": 1920,
+            "numeric-id": false
         },
 
         "mangadex":

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -313,7 +313,8 @@
             "metadata": false,
             "profile" : false,
             "size-max": null,
-            "videos"  : true
+            "videos"  : true,
+            "numeric-id": false
         },
         "furaffinity":
         {

--- a/docs/options.md
+++ b/docs/options.md
@@ -70,6 +70,7 @@
                                 the current directory to debug problems
     --print-traffic             Display sent and read HTTP traffic
     --no-colors                 Do not emit ANSI color codes in output
+    --numeric-id                Use numeric Flickr user IDs as directory names
 
 ## Networking Options:
     -R, --retries N             Maximum number of retries for failed HTTP

--- a/gallery_dl/extractor/flickr.py
+++ b/gallery_dl/extractor/flickr.py
@@ -27,6 +27,13 @@ class FlickrExtractor(Extractor):
         self.api = FlickrAPI(self)
         self.user = None
         self.item_id = self.groups[0]
+        if self.config("numeric-id", False):
+            def repl(segment):
+                return segment.replace("{user[username]}", "{user[nsid]}")
+            if isinstance(self.directory_fmt, tuple):
+                self.directory_fmt = tuple(repl(s) for s in self.directory_fmt)
+            else:
+                self.directory_fmt = repl(self.directory_fmt)
 
     def items(self):
         data = self.metadata()

--- a/gallery_dl/option.py
+++ b/gallery_dl/option.py
@@ -153,6 +153,12 @@ class UgoiraAction(argparse.Action):
         namespace.postprocessors.append(pp)
 
 
+class FlickrNumericIdAction(argparse.Action):
+    """Enable numeric Flickr user IDs"""
+    def __call__(self, parser, namespace, values, option_string=None):
+        namespace.options.append((("extractor", "flickr"), "numeric-id", True))
+
+
 class PrintAction(argparse.Action):
     def __call__(self, parser, namespace, value, option_string=None):
         if self.const:
@@ -468,6 +474,11 @@ def build_parser():
         "--no-colors",
         dest="colors", action="store_false",
         help="Do not emit ANSI color codes in output",
+    )
+    output.add_argument(
+        "--numeric-id",
+        action=FlickrNumericIdAction, nargs=0,
+        help="Use numeric Flickr user IDs as directory names",
     )
 
     networking = parser.add_argument_group("Networking Options")


### PR DESCRIPTION
## Summary
- add `--numeric-id` command line flag
- store numeric Flickr ID in `directory_fmt` when flag is set
- document the new option and configuration

## Testing
- `scripts/run_tests.py` *(fails: AttributeError in test_cookies due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6870baccc5708329ae3bffab542b33d2